### PR TITLE
Fixing #3 issue by intoducing one new env var and changing start command.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,7 @@ ENV N8N_BASIC_AUTH_PASSWORD=$PASSWORD
 
 ENV ENABLE_ALPINE_PRIVATE_NETWORKING=true
 
+ENV TINI_SUBREAPER=true
+
 # Start n8n with the 'start' command
 CMD ["start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ RUN chown -R node:node /home/node/.n8n
 USER node
 
 # Start n8n with the 'start' command
-CMD ["/home/node/.n8n", "start"]
+CMD ["ls", /home/node/]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,18 +22,5 @@ ENV N8N_BASIC_AUTH_PASSWORD=$PASSWORD
 
 ENV ENABLE_ALPINE_PRIVATE_NETWORKING=true
 
-RUN ls -la /home/node/
-RUN ls -la /home/node/.n8n
-
-# Change to the new n8n directory
-WORKDIR /home/node/.n8n
-
-# Ensure the 'node' user owns the /home/node/.n8n directory
-# This is crucial for permission management
-RUN chown -R node:node /home/node/.n8n
-
-# Switch to 'node' user for security purposes
-USER node
-
 # Start n8n with the 'start' command
-CMD ["/home/node/.n8n/n8n", "start"]
+CMD ["start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ RUN chown -R node:node /home/node/.n8n
 USER node
 
 # Start n8n with the 'start' command
-CMD ["n8n", "start"]
+CMD ["/home/node/.n8n", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ ENV N8N_BASIC_AUTH_PASSWORD=$PASSWORD
 
 ENV ENABLE_ALPINE_PRIVATE_NETWORKING=true
 
+RUN ls -la /home/node/
+RUN ls -la /home/node/.n8n
+
 # Change to the new n8n directory
 WORKDIR /home/node/.n8n
 
@@ -33,4 +36,4 @@ RUN chown -R node:node /home/node/.n8n
 USER node
 
 # Start n8n with the 'start' command
-CMD ["ls", /home/node/]
+CMD ["/home/node/.n8n/n8n", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,15 @@ ENV N8N_BASIC_AUTH_PASSWORD=$PASSWORD
 
 ENV ENABLE_ALPINE_PRIVATE_NETWORKING=true
 
+# Change to the new n8n directory
+WORKDIR /home/node/.n8n
+
+# Ensure the 'node' user owns the /home/node/.n8n directory
+# This is crucial for permission management
+RUN chown -R node:node /home/node/.n8n
+
+# Switch to 'node' user for security purposes
+USER node
+
+# Start n8n with the 'start' command
 CMD ["n8n", "start"]


### PR DESCRIPTION
It seems the problem of #3 is actually a semantics change in v 1.x of n8n : https://community.n8n.io/t/n8n-1-x-not-starting-well/28619

rather than do `n8n start` it's enough to just do `start` now.

I also introduced defult env var for TINI to avoid this warning : [WARN tini (7)] Tini is not running as PID 1 and isn't registered as a child subreaper.

It seems just changing run command to "start" in config is not enough, but changing dockerfile in proposed way seems to work if i deploy from by branch. I will try now to set up full-blown template of mine to make sure this works.